### PR TITLE
Fix PHP 8.4 deprecation issues

### DIFF
--- a/src/Http/Controllers/SortableController.php
+++ b/src/Http/Controllers/SortableController.php
@@ -20,7 +20,8 @@ class SortableController
         $relationshipType = $request->input('relationshipType');
 
         // Reverse the array if it is configured to order by DESC.
-        if ($request->resource()::getOrderByDirection($validationResult->sortable) === 'DESC') {
+        $resourceClass = $request->resource();
+        if ($resourceClass::getOrderByDirection($validationResult->sortable) === 'DESC') {
             $resourceIds = array_reverse($resourceIds);
         }
 
@@ -138,7 +139,8 @@ class SortableController
     public function moveToStart(NovaRequest $request)
     {
         $validationResult = $this->validateRequest($request);
-        $sort_desc = $request->resource()::getOrderByDirection($validationResult->sortable) == 'DESC';
+        $resourceClass = $request->resource();
+        $sort_desc = $resourceClass::getOrderByDirection($validationResult->sortable) == 'DESC';
         $method = $sort_desc ? 'moveToEnd' : 'moveToStart';
         $validationResult->model->{$method}();
         return response('', 204);
@@ -147,7 +149,8 @@ class SortableController
     public function moveToEnd(NovaRequest $request)
     {
         $validationResult = $this->validateRequest($request);
-        $sort_desc = $request->resource()::getOrderByDirection($validationResult->sortable) == 'DESC';
+        $resourceClass = $request->resource();
+        $sort_desc = $resourceClass::getOrderByDirection($validationResult->sortable) == 'DESC';
         $method = $sort_desc ? 'moveToStart' : 'moveToEnd';
         $validationResult->model->{$method}();
         return response('', 204);
@@ -165,7 +168,8 @@ class SortableController
             'viaResourceId' => 'present',
         ]);
 
-        return $request->resource()::getSortability($request);
+        $resourceClass = $request->resource();
+        return $resourceClass::getSortability($request);
     }
 
     protected function fixSortOrder($sortOrder)

--- a/src/Traits/HasSortableRows.php
+++ b/src/Traits/HasSortableRows.php
@@ -36,7 +36,7 @@ trait HasSortableRows
 
         if ($request instanceof LensRequest) return null;
 
-        $model = $resource->resource ?? $resource ?? null;
+        $model = $resource->resource ?? $resource;
         if (!$model || !self::canSort($request, $model)) {
             return (static::$sortabilityCache[static::class] = (object)['canSort' => false]);
         }


### PR DESCRIPTION
## Summary
Resolves PHP 8.4 deprecation issues identified in issue #15.

## Changes Made
- **SortableController.php**: Fixed undefined static method calls by properly extracting resource class before calling `getOrderByDirection()` and `getSortability()` methods
- **HasSortableRows.php**: Removed redundant null coalescing operator that was causing static analysis warnings

## Test Plan
- [x] PHP syntax validation passes on all modified files
- [x] All undefined method call warnings resolved
- [x] Nullable variable warnings resolved

Closes #15