### PR TITLE
Allow spatie/eloquent-sortable ^5.0 (Laravel 13 support)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "require": {
     "php": ">=8.0",
-    "spatie/eloquent-sortable": "^3.10.0|^4.0",
+    "spatie/eloquent-sortable": "^3.10.0|^4.0|^5.0",
     "laravel/nova": "^4.24.0|^5.0",
     "outl1ne/nova-translations-loader": "^5.0"
   },


### PR DESCRIPTION
## Why

`marshmallow/nova-sortable` blocks Laravel 13 upgrades. It depends on `spatie/eloquent-sortable: ^3.10.0|^4.0`, and the `^4.x` line caps at `illuminate ^12`. Laravel 13 support lands in `spatie/eloquent-sortable` **5.0.1**.

## Change

Widen the constraint additively:

```diff
- "spatie/eloquent-sortable": "^3.10.0|^4.0",
+ "spatie/eloquent-sortable": "^3.10.0|^4.0|^5.0",
```

Backward compatible — older apps (PHP < 8.2 / Laravel < 10) keep resolving `^4.x`; Laravel 13 apps resolve `^5`.

## Compatibility

The only eloquent-sortable surface used in this package ([`src/Traits/HasSortableRows.php`](src/Traits/HasSortableRows.php)) is the `Spatie\EloquentSortable\SortableTrait` existence check and the `eloquent-sortable` config key — both unchanged in v5. The v5 [breaking changes](https://github.com/spatie/eloquent-sortable/blob/main/CHANGELOG.md) (PHP 8.2 min, Laravel 10 min, `moveAfter`/`moveBefore` now fire model events) do not affect this package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)